### PR TITLE
Up the waiting period on shutdown from 5 minutes to 3 hours for mongo…

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES
 
 GRAPH
   apt (6.1.3)
-  mongodb (0.12.15)
+  mongodb (0.12.16)
     apt (>= 1.8.2)
     yum (>= 0.0.0)
   yum (5.0.1)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Evergage"
 maintainer_email  "oleg+chef-mongo@evergage.com"
 license           "Apache 2.0"
 description       "Installs and configures mongodb >=3.2"
-version           "0.12.15"
+version           "0.12.16"
 
 recipe "mongodb", "Installs and configures a single node mongodb instance"
 recipe "mongodb::10gen_repo", "Adds the 10gen repo to get the latest packages"

--- a/templates/default/redhat-mongodb.init.erb
+++ b/templates/default/redhat-mongodb.init.erb
@@ -29,7 +29,7 @@ start()
 stop()
 {
   echo -n $"Stopping <%= @provides %>: "
-  killproc -p <%= @pidfile %> -d 300 $DAEMON
+  killproc -p <%= @pidfile %> -d 10800 $DAEMON
   RETVAL=$?
   echo
   [ $RETVAL -eq 0 ] && rm -f $SUBSYS_LOCK_FILE


### PR DESCRIPTION
… processes, to essentially disable the stop script from doing a kill -9.  We need this because stopping a mongo 4.4 process while the whole cluster isn't yet in 4.4 FCV compat mode takes more than 5 minutes, as it has to do a lengthy process to write its store back in a 4.2 backwards compatible mode.  If the stop script kill -9's the process during this, then the db won't be able to be brought back up with 4.2 at all.

Note that there wasn't a good way to disable the delay at all in the redhat scripts, which rely upon this weird internally shipped redhat killproc functions, so I just upped the timeout to 3 hours to effectively make it long enough.